### PR TITLE
Fix setupTests.js

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -10,6 +10,7 @@ beforeAll(() => jest.spyOn(window, "fetch"));
 const mockFetch = () =>
   Promise.resolve({
     json: () => Promise.resolve(data),
+    ok: true,
   });
 
 beforeEach(() => window.fetch.mockImplementation(mockFetch));


### PR DESCRIPTION
This PR fixes the mocked window.fetch used in the tests by adding `ok: true` to the response. 