### PR TITLE
Fix: Test cases for 'Loading' and 'No data' assertions

### DIFF
--- a/src/tests/task_2.test.js
+++ b/src/tests/task_2.test.js
@@ -17,6 +17,17 @@ const renderRocketsList = (filterParams = testFilterParamsList[0]) =>
   render(<RocketsList filterParams={filterParams} />);
 
 describe("# RocketsList", () => {
+  it(`renders ${LOADING_LABEL} while fetching data`, async () => {
+    const mockFetch = () => new Promise(() => {});
+
+    window.fetch.mockImplementation(mockFetch);
+
+    const { getByText, queryByText } = renderRocketsList();
+
+    await waitFor(() => expect(getByText(LOADING_LABEL)).toBeInTheDocument());
+    expect(queryByText(NO_DATA_LABEL)).not.toBeInTheDocument();
+  });
+
   it("renders 'Loading...' while fetching data, and 'No data' on no missions obtained", async () => {
     const mockFetch = () =>
       Promise.resolve({
@@ -25,33 +36,34 @@ describe("# RocketsList", () => {
 
     window.fetch.mockImplementation(mockFetch);
 
-    const { getByText } = renderRocketsList();
+    const { getByText, queryByText } = renderRocketsList();
 
-    await waitFor(() => {
-      expect(getByText(LOADING_LABEL)).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(getByText(NO_DATA_LABEL)).toBeInTheDocument();
-    });
+    expect(getByText(LOADING_LABEL)).toBeInTheDocument();
+    await waitFor(() => expect(getByText(NO_DATA_LABEL)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(queryByText(LOADING_LABEL)).not.toBeInTheDocument()
+    );
   });
 
   it("fetches the whole list of mission from SpaceX API", async () => {
-    const { getByText } = renderRocketsList();
+    const { getByText, queryByText } = renderRocketsList();
 
     // to avoid RTL 'act' warning
-    await waitFor(() => {
-      expect(getByText(LOADING_LABEL)).toBeInTheDocument();
-    });
+    await waitFor(() => expect(getByText(LOADING_LABEL)).toBeInTheDocument());
 
     expect(window.fetch).toHaveBeenCalledTimes(1);
     expect(window.fetch).toHaveBeenCalledWith(API_URL);
+
+    expect(queryByText(LOADING_LABEL)).not.toBeInTheDocument();
+    expect(queryByText(NO_DATA_LABEL)).not.toBeInTheDocument();
   });
 
   it("should re-process missions with prepareData every time filterParams change, but not call API anymore", async () => {
     const prepareDataSpy = jest.spyOn(TaskOneSolution, "prepareData");
 
-    const { rerender, getByText } = renderRocketsList(testFilterParamsList[0]);
+    const { rerender, getByText, queryByText } = renderRocketsList(
+      testFilterParamsList[0]
+    );
 
     expect(prepareDataSpy).toHaveBeenCalledTimes(1);
     expect(prepareDataSpy).toHaveBeenCalledWith(testFilterParamsList[0]);
@@ -65,11 +77,12 @@ describe("# RocketsList", () => {
     expect(window.fetch).toHaveBeenCalledTimes(1);
 
     // to avoid RTL 'act' warning
-    await waitFor(() => {
-      expect(getByText(LOADING_LABEL)).toBeInTheDocument();
-    });
+    await waitFor(() => expect(getByText(LOADING_LABEL)).toBeInTheDocument());
 
     prepareDataSpy.mockRestore();
+
+    expect(queryByText(LOADING_LABEL)).not.toBeInTheDocument();
+    expect(queryByText(NO_DATA_LABEL)).not.toBeInTheDocument();
   });
 
   describe("renders all obtained missions correctly", () => {


### PR DESCRIPTION
## Description
Fix test cases such that
- Loading... shouldn't be in the document when No data is rendered
- No data shouldn't be in the document whilst we are still fetching (i.e. Loading is in the document)
- Loading... & No data shouldn't be in the document after missions data are rendered

![CleanShot 2023-04-27 at 08 39 34@2x](https://github.com/adjust/react-and-rockets/assets/5154605/0433d55d-3c99-41c9-9be7-4a85211a0ccc)
